### PR TITLE
Add workflow to publish docs

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -1,0 +1,23 @@
+name: Publish docs
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - '.github/workflows/mkdocs.yml'
+      - 'mkdocs.yml'
+jobs:
+  mkdocs:
+    name: Publish docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Deploy docs
+        uses: mhausenblas/mkdocs-deploy-gh-pages@master
+        env:
+          REQUIREMENTS: docs/requirements.txt
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This package encapsulates the data exchange needed to verify one or more eligibility criteria for transit benefits.
 
+View the technical documentation online: <https://docs.calitp.org/eligibility-api>
+
 ## License
 
 [Apache 2.0 License](./LICENSE)


### PR DESCRIPTION
Requires #8 to be merged in to `main` so that root-level docs published

# What this PR does
 - GitHub Actions: Adds a GitHub workflow to publish and deploy docs

## Post-merge actions
 - Once the published site looks as desired, merge cal-itp/eligibility-server#49
