### PR TITLE
Set up initial package

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -20,6 +20,10 @@ RUN python -m pip install --upgrade pip && \
 # enter src directory
 WORKDIR /home/$USER/src
 
+# install python dependencies
+COPY requirements.txt requirements.txt
+RUN pip install -r requirements.txt
+
 # install docs tooling:
 COPY docs/requirements.txt docs/requirements.txt
 RUN pip install --no-cache-dir -r docs/requirements.txt

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ __pycache__/
 .pytest_cache/
 .coverage
 .DS_Store
+build/
+eligibility.egg-info/

--- a/eligibility/api.py
+++ b/eligibility/api.py
@@ -1,0 +1,177 @@
+import datetime
+import json
+import logging
+import uuid
+import requests
+
+from jwcrypto import common as jwcrypto, jwe, jws, jwt
+
+
+logger = logging.getLogger(__name__)
+
+
+class ApiError(Exception):
+    """Error calling the Eligibility Verification API."""
+
+    pass
+
+
+class TokenError(Exception):
+    """Error with API request/response token."""
+
+    pass
+
+
+class RequestToken:
+    """Eligibility Verification API request token."""
+
+    def __init__(self, agency, verifier, sub, name, issuer):
+        logger.info("Initialize new request token")
+
+        # send the eligibility type names
+        types = list(map(lambda t: t.name, agency.types_to_verify()))
+
+        # craft the main token payload
+        payload = dict(
+            jti=str(uuid.uuid4()),
+            iss=issuer,
+            iat=int(
+                datetime.datetime.utcnow()
+                .replace(tzinfo=datetime.timezone.utc)
+                .timestamp()
+            ),
+            agency=agency.agency_id,
+            eligibility=types,
+            sub=sub,
+            name=name,
+        )
+
+        logger.debug("Sign token payload with agency's private key")
+        header = {"typ": "JWS", "alg": agency.jws_signing_alg}
+        signed_token = jwt.JWT(header=header, claims=payload)
+        signed_token.make_signed_token(agency.private_jwk)
+        signed_payload = signed_token.serialize()
+
+        logger.debug("Encrypt signed token payload with verifier's public key")
+        header = {
+            "typ": "JWE",
+            "alg": verifier.jwe_encryption_alg,
+            "enc": verifier.jwe_cek_enc,
+        }
+        encrypted_token = jwt.JWT(header=header, claims=signed_payload)
+        encrypted_token.make_encrypted_token(verifier.public_jwk)
+
+        logger.info("Signed and encrypted request token initialized")
+        self._jwe = encrypted_token
+
+    def __repr__(self):
+        return str(self)
+
+    def __str__(self):
+        return self._jwe.serialize()
+
+
+class ResponseToken:
+    """Eligibility Verification API response token."""
+
+    def __init__(self, response, agency, verifier):
+        logger.info("Read encrypted token from response")
+
+        try:
+            encrypted_signed_token = response.text
+            if not encrypted_signed_token:
+                raise ValueError()
+            # strip extra spaces and wrapping quote chars
+            encrypted_signed_token = encrypted_signed_token.strip("'\n\"")
+        except ValueError:
+            raise TokenError("Invalid response format")
+
+        logger.debug("Decrypt response token using agency's private key")
+        allowed_algs = [verifier.jwe_encryption_alg, verifier.jwe_cek_enc]
+        decrypted_token = jwe.JWE(algs=allowed_algs)
+        try:
+            decrypted_token.deserialize(encrypted_signed_token, key=agency.private_jwk)
+        except jwe.InvalidJWEData:
+            raise TokenError("Invalid JWE token")
+        except jwe.InvalidJWEOperation:
+            raise TokenError("JWE token decryption failed")
+
+        decrypted_payload = str(decrypted_token.payload, "utf-8")
+
+        logger.debug(
+            "Verify decrypted response token's signature using verifier's public key"
+        )
+        signed_token = jws.JWS()
+        try:
+            signed_token.deserialize(
+                decrypted_payload, key=verifier.public_jwk, alg=agency.jws_signing_alg
+            )
+        except jws.InvalidJWSObject:
+            raise TokenError("Invalid JWS token")
+        except jws.InvalidJWSSignature:
+            raise TokenError("JWS token signature verification failed")
+
+        logger.info("Response token decrypted and signature verified")
+
+        payload = json.loads(str(signed_token.payload, "utf-8"))
+        self.eligibility = list(payload.get("eligibility", []))
+        self.error = payload.get("error", None)
+
+
+class Client:
+    """Eligibility Verification API HTTP client."""
+
+    def __init__(self, agency, issuer):
+        logger.debug(f"Initialize client for agency: {agency.short_name}")
+        self.agency = agency
+        self.verifier = agency.eligibility_verifier
+        self.issuer = issuer
+
+    def _tokenize_request(self, sub, name):
+        """Create a request token."""
+        return RequestToken(self.agency, self.verifier, sub, name, self.issuer)
+
+    def _tokenize_response(self, response):
+        """Parse a response token."""
+        return ResponseToken(response, self.agency, self.verifier)
+
+    def _auth_headers(self, token):
+        """Create headers for the request with the token and verifier API keys"""
+        headers = dict(Authorization=f"Bearer {token}")
+        headers[self.verifier.api_auth_header] = self.verifier.api_auth_key
+        return headers
+
+    def _request(self, sub, name):
+        """Make an API request for eligibility verification."""
+        logger.debug("Start new eligibility verification request")
+
+        try:
+            token = self._tokenize_request(sub, name)
+        except jwcrypto.JWException:
+            raise TokenError("Failed to tokenize form values")
+
+        try:
+            logger.debug(f"GET request to {self.verifier.api_url}")
+            r = requests.get(self.verifier.api_url, headers=self._auth_headers(token))
+        except requests.ConnectionError:
+            raise ApiError("Connection to verification server failed")
+        except requests.Timeout:
+            raise ApiError("Connection to verification server timed out")
+        except requests.TooManyRedirects:
+            raise ApiError("Too many redirects to verification server")
+        except requests.HTTPError as e:
+            raise ApiError(e)
+
+        expected_status_codes = {200, 400}
+        if r.status_code in expected_status_codes:
+            logger.debug("Process eligiblity verification response")
+            return self._tokenize_response(r)
+        else:
+            logger.warning(
+                f"Unexpected eligibility verification response status code: {r.status_code}"
+            )
+            raise ApiError("Unexpected eligibility verification response")
+
+    def verify(self, sub, name):
+        """Check eligibility for the subject and name."""
+        return self._request(sub, name)

--- a/eligibility/api.py
+++ b/eligibility/api.py
@@ -4,7 +4,8 @@ import logging
 import uuid
 import requests
 
-from jwcrypto import common as jwcrypto, jwe, jws, jwt
+from jwcrypto import common as jwcrypto, jwe, jws, jwt, jwk
+from typing import Iterable
 
 
 logger = logging.getLogger(__name__)
@@ -25,11 +26,20 @@ class TokenError(Exception):
 class RequestToken:
     """Eligibility Verification API request token."""
 
-    def __init__(self, agency, verifier, sub, name, issuer):
+    def __init__(
+        self,
+        types: Iterable[str],
+        agency_id: str,
+        jws_signing_alg: str,
+        client_private_jwk: jwk.JWK,
+        jwe_encryption_alg: str,
+        jwe_cek_enc: str,
+        server_public_jwk: jwk.JWK,
+        sub: str,
+        name: str,
+        issuer: str,
+    ):
         logger.info("Initialize new request token")
-
-        # send the eligibility type names
-        types = list(map(lambda t: t.name, agency.types_to_verify()))
 
         # craft the main token payload
         payload = dict(
@@ -40,26 +50,26 @@ class RequestToken:
                 .replace(tzinfo=datetime.timezone.utc)
                 .timestamp()
             ),
-            agency=agency.agency_id,
+            agency=agency_id,
             eligibility=types,
             sub=sub,
             name=name,
         )
 
         logger.debug("Sign token payload with agency's private key")
-        header = {"typ": "JWS", "alg": agency.jws_signing_alg}
+        header = {"typ": "JWS", "alg": jws_signing_alg}
         signed_token = jwt.JWT(header=header, claims=payload)
-        signed_token.make_signed_token(agency.private_jwk)
+        signed_token.make_signed_token(client_private_jwk)
         signed_payload = signed_token.serialize()
 
         logger.debug("Encrypt signed token payload with verifier's public key")
         header = {
             "typ": "JWE",
-            "alg": verifier.jwe_encryption_alg,
-            "enc": verifier.jwe_cek_enc,
+            "alg": jwe_encryption_alg,
+            "enc": jwe_cek_enc,
         }
         encrypted_token = jwt.JWT(header=header, claims=signed_payload)
-        encrypted_token.make_encrypted_token(verifier.public_jwk)
+        encrypted_token.make_encrypted_token(server_public_jwk)
 
         logger.info("Signed and encrypted request token initialized")
         self._jwe = encrypted_token
@@ -74,7 +84,15 @@ class RequestToken:
 class ResponseToken:
     """Eligibility Verification API response token."""
 
-    def __init__(self, response, agency, verifier):
+    def __init__(
+        self,
+        response: requests.models.Response,
+        jwe_encryption_alg: str,
+        jwe_cek_enc: str,
+        client_private_jwk: jwk.JWK,
+        jws_signing_alg: str,
+        server_public_jwk: jwk.JWK,
+    ):
         logger.info("Read encrypted token from response")
 
         try:
@@ -87,10 +105,10 @@ class ResponseToken:
             raise TokenError("Invalid response format")
 
         logger.debug("Decrypt response token using agency's private key")
-        allowed_algs = [verifier.jwe_encryption_alg, verifier.jwe_cek_enc]
+        allowed_algs = [jwe_encryption_alg, jwe_cek_enc]
         decrypted_token = jwe.JWE(algs=allowed_algs)
         try:
-            decrypted_token.deserialize(encrypted_signed_token, key=agency.private_jwk)
+            decrypted_token.deserialize(encrypted_signed_token, key=client_private_jwk)
         except jwe.InvalidJWEData:
             raise TokenError("Invalid JWE token")
         except jwe.InvalidJWEOperation:
@@ -104,7 +122,7 @@ class ResponseToken:
         signed_token = jws.JWS()
         try:
             signed_token.deserialize(
-                decrypted_payload, key=verifier.public_jwk, alg=agency.jws_signing_alg
+                decrypted_payload, key=server_public_jwk, alg=jws_signing_alg
             )
         except jws.InvalidJWSObject:
             raise TokenError("Invalid JWS token")
@@ -123,22 +141,52 @@ class Client:
 
     def __init__(self, agency, issuer):
         logger.debug(f"Initialize client for agency: {agency.short_name}")
-        self.agency = agency
-        self.verifier = agency.eligibility_verifier
         self.issuer = issuer
+
+        verifier = agency.eligibility_verifier
+        # get the eligibility type names
+        self.types = list(map(lambda t: t.name, agency.types_to_verify()))
+        self.agency_id = agency.agency_id
+        self.jws_signing_alg = agency.jws_signing_alg
+        self.client_private_jwk = agency.private_jwk
+        self.jwe_encryption_alg = verifier.jwe_encryption_alg
+        self.jwe_cek_enc = verifier.jwe_cek_enc
+        self.server_public_jwk = verifier.public_jwk
+
+        self.api_url = verifier.api_url
+        self.api_auth_header = verifier.api_auth_header
+        self.api_auth_key = verifier.api_auth_key
 
     def _tokenize_request(self, sub, name):
         """Create a request token."""
-        return RequestToken(self.agency, self.verifier, sub, name, self.issuer)
+        return RequestToken(
+            self.types,
+            self.agency_id,
+            self.jws_signing_alg,
+            self.client_private_jwk,
+            self.jwe_encryption_alg,
+            self.jwe_cek_enc,
+            self.server_public_jwk,
+            sub,
+            name,
+            self.issuer,
+        )
 
     def _tokenize_response(self, response):
         """Parse a response token."""
-        return ResponseToken(response, self.agency, self.verifier)
+        return ResponseToken(
+            response,
+            self.jwe_encryption_alg,
+            self.jwe_cek_enc,
+            self.client_private_jwk,
+            self.jws_signing_alg,
+            self.server_public_jwk,
+        )
 
     def _auth_headers(self, token):
         """Create headers for the request with the token and verifier API keys"""
         headers = dict(Authorization=f"Bearer {token}")
-        headers[self.verifier.api_auth_header] = self.verifier.api_auth_key
+        headers[self.api_auth_header] = self.api_auth_key
         return headers
 
     def _request(self, sub, name):
@@ -151,8 +199,8 @@ class Client:
             raise TokenError("Failed to tokenize form values")
 
         try:
-            logger.debug(f"GET request to {self.verifier.api_url}")
-            r = requests.get(self.verifier.api_url, headers=self._auth_headers(token))
+            logger.debug(f"GET request to {self.api_url}")
+            r = requests.get(self.api_url, headers=self._auth_headers(token))
         except requests.ConnectionError:
             raise ApiError("Connection to verification server failed")
         except requests.Timeout:

--- a/eligibility/verify.py
+++ b/eligibility/verify.py
@@ -1,0 +1,72 @@
+import datetime
+import json
+import logging
+
+from jwcrypto import jwe, jws, jwk, jwt
+
+logger = logging.getLogger(__name__)
+
+
+def get_token_payload(
+    token: str,
+    jwe_encryption_alg: str,
+    jwe_cek_enc: str,
+    server_private_key: jwk.JWK,
+    jws_signing_alg: str,
+    client_public_key: jwk.JWK,
+) -> dict:
+    """Decode a token (JWE(JWS))."""
+    try:
+        # decrypt
+        decrypted_token = jwe.JWE(algs=[jwe_encryption_alg, jwe_cek_enc])
+        decrypted_token.deserialize(token, key=server_private_key)
+        decrypted_payload = str(decrypted_token.payload, "utf-8")
+        # verify signature
+        signed_token = jws.JWS()
+        signed_token.deserialize(
+            decrypted_payload, key=client_public_key, alg=jws_signing_alg
+        )
+        # return final payload
+        payload = str(signed_token.payload, "utf-8")
+        return json.loads(payload)
+    except Exception:
+        return False
+
+
+def create_response_payload(token_payload: dict, issuer: str) -> dict:
+    """Crafts a response payload. Does not include the eligibility or error fields."""
+    # craft the response payload using parsed request token
+    resp_payload = dict(
+        jti=token_payload["jti"],
+        iss=issuer,
+        iat=int(
+            datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).timestamp()
+        ),
+    )
+
+    return resp_payload
+
+
+def make_token(
+    payload: dict,
+    jws_signing_alg: str,
+    server_private_key: jwk.JWK,
+    jwe_encryption_alg: str,
+    jwe_cek_enc: str,
+    client_public_key: jwk.JWK,
+) -> str:
+    """Wrap payload in a signed and encrypted JWT for response."""
+    # sign the payload with server's private key
+    header = {"typ": "JWS", "alg": jws_signing_alg}
+    signed_token = jwt.JWT(header=header, claims=payload)
+    signed_token.make_signed_token(server_private_key)
+    signed_payload = signed_token.serialize()
+    # encrypt the signed payload with client's public key
+    header = {
+        "typ": "JWE",
+        "alg": jwe_encryption_alg,
+        "enc": jwe_cek_enc,
+    }
+    encrypted_token = jwt.JWT(header=header, claims=signed_payload)
+    encrypted_token.make_encrypted_token(client_public_key)
+    return encrypted_token.serialize()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel"
+]
+build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+jwcrypto==1.0
+requests==2.27.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,5 +15,5 @@ classifiers =
 packages = find:
 python_requires = >=3.9
 install_requires =
-    jwcrypto==1.0
-    requests==2.27.1
+    jwcrypto>=1.0
+    requests>=2.27.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,19 @@
+[metadata]
+name = eligibility
+version = 2022.01.1
+description = Data exchange to verify eligibility for transit benefits
+url = https://github.com/cal-itp/eligibility-api
+project_urls =
+    Bug Tracker = https://github.com/cal-itp/eligibility-api/issues
+license = 'Apache 2.0'
+classifiers =
+    Programming Language :: Python :: 3
+    License :: OSI Approved :: Apache Software License
+    Operating System :: OS Independent
+
+[options]
+packages = find:
+python_requires = >=3.9
+install_requires =
+    jwcrypto==1.0
+    requests==2.27.1


### PR DESCRIPTION
Related to cal-itp/benefits#141 and cal-itp/eligibility-server#38

This PR sets up a Python package that contains code extracted from [cal-itp/benefits](https://github.com/cal-itp/benefits) and [cal-itp/eligibility-server](https://github.com/cal-itp/eligibility-server).

### Work done
- Added `pyproject.toml` and `setup.cfg` to make it installable as a package using pip
- Copied `eligibility/api.py` from `benefits`
   - Made necessary changes to method signatures, and removed internal dependency on Django models
- Copied functions from `verify.py` from `eligibility-server`
   - Made necessary changes to method signatures
- Left implementations untouched