### PR TITLE
Update black pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: check-added-large-files
 
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
       - id: black
         types:


### PR DESCRIPTION
Updates `black` pre-commit hook to `22.3.0`.

Similar to https://github.com/cal-itp/benefits/issues/360, our previous version of the `black` formatter was causing our `pre-commit` GitHub Actions to fail. (for example: https://github.com/cal-itp/eligibility-api/runs/6419025921?check_suite_focus=true)


```
[INFO] This may take a few minutes...
Trim Trailing Whitespace.................................................Passed
Mixed line ending........................................................Passed
Fix End of Files.........................................................Passed
Fix requirements.txt.....................................................Passed
Check Yaml...............................................................Passed
Check for added large files..............................................Passed
black....................................................................Failed
- hook id: black
- exit code: 1

Traceback (most recent call last):
  File "/home/runner/.cache/pre-commit/repog5zovmx9/py_env-python3/bin/black", line 8, in <module>
    sys.exit(patched_main())
  File "/home/runner/.cache/pre-commit/repog5zovmx9/py_env-python3/lib/python3.10/site-packages/black/__init__.py", line 6606, in patched_main
    patch_click()
  File "/home/runner/.cache/pre-commit/repog5zovmx9/py_env-python3/lib/python3.10/site-packages/black/__init__.py", line 6595, in patch_click
    from click import _unicodefun  # type: ignore
ImportError: cannot import name '_unicodefun' from 'click' (/home/runner/.cache/pre-commit/repog5zovmx9/py_env-python3/lib/python3.10/site-packages/click/__init__.py)

flake8...................................................................Passed
bandit...................................................................Passed
markdownlint.............................................................Passed
Error: The process '/opt/hostedtoolcache/Python/3.10.4/x64/bin/pre-commit' failed with exit code 1
```