### PR TITLE
Refactor: change JWK parameter

### DIFF
--- a/eligibility_api/client.py
+++ b/eligibility_api/client.py
@@ -23,6 +23,22 @@ class TokenError(Exception):
     pass
 
 
+class JWK:
+    """JSON Web Key for use during signing or encrypting."""
+
+    @classmethod
+    def from_pem(cls, data, password=None):
+        obj = cls()
+        obj.key = jwk.JWK.from_pem(data, password)
+        return obj
+
+    def __repr__(self):
+        return str(self)
+
+    def __str__(self):
+        return str(self.key)
+
+
 class RequestToken:
     """Eligibility Verification API request token."""
 
@@ -145,10 +161,10 @@ class Client:
         issuer: str,
         agency: str,
         jws_signing_alg: str,
-        client_private_jwk: jwk.JWK,
+        client_private_jwk: JWK,
         jwe_encryption_alg: str,
         jwe_cek_enc: str,
-        server_public_jwk: jwk.JWK,
+        server_public_jwk: JWK,
         headers={},
     ):
         self.verify_url = verify_url
@@ -156,10 +172,10 @@ class Client:
         self.issuer = issuer
         self.agency = agency
         self.jws_signing_alg = jws_signing_alg
-        self.client_private_jwk = client_private_jwk
+        self.client_private_jwk = client_private_jwk.key
         self.jwe_encryption_alg = jwe_encryption_alg
         self.jwe_cek_enc = jwe_cek_enc
-        self.server_public_jwk = server_public_jwk
+        self.server_public_jwk = server_public_jwk.key
 
         if "authorization" in set(k.lower() for k in headers):
             raise ValueError(

--- a/eligibility_api/client.py
+++ b/eligibility_api/client.py
@@ -1,13 +1,9 @@
-import datetime
-import json
 import logging
-import uuid
 import requests
 
-from jwcrypto import common as jwcrypto, jwe, jws, jwt, jwk
-from typing import Iterable
+from jwcrypto import common as jwcrypto
 
-from .common import create_jwk
+from .tokens import create_jwk, RequestToken, ResponseToken, TokenError
 
 
 logger = logging.getLogger(__name__)
@@ -17,125 +13,6 @@ class ApiError(Exception):
     """Error calling the Eligibility Verification API."""
 
     pass
-
-
-class TokenError(Exception):
-    """Error with API request/response token."""
-
-    pass
-
-
-class RequestToken:
-    """Eligibility Verification API request token."""
-
-    def __init__(
-        self,
-        types: Iterable[str],
-        agency: str,
-        jws_signing_alg: str,
-        client_private_jwk: jwk.JWK,
-        jwe_encryption_alg: str,
-        jwe_cek_enc: str,
-        server_public_jwk: jwk.JWK,
-        sub: str,
-        name: str,
-        issuer: str,
-    ):
-        logger.info("Initialize new request token")
-
-        # craft the main token payload
-        payload = dict(
-            jti=str(uuid.uuid4()),
-            iss=issuer,
-            iat=int(
-                datetime.datetime.utcnow()
-                .replace(tzinfo=datetime.timezone.utc)
-                .timestamp()
-            ),
-            agency=agency,
-            eligibility=types,
-            sub=sub,
-            name=name,
-        )
-
-        logger.debug("Sign token payload with agency's private key")
-        header = {"typ": "JWS", "alg": jws_signing_alg}
-        signed_token = jwt.JWT(header=header, claims=payload)
-        signed_token.make_signed_token(client_private_jwk)
-        signed_payload = signed_token.serialize()
-
-        logger.debug("Encrypt signed token payload with verifier's public key")
-        header = {
-            "typ": "JWE",
-            "alg": jwe_encryption_alg,
-            "enc": jwe_cek_enc,
-        }
-        encrypted_token = jwt.JWT(header=header, claims=signed_payload)
-        encrypted_token.make_encrypted_token(server_public_jwk)
-
-        logger.info("Signed and encrypted request token initialized")
-        self._jwe = encrypted_token
-
-    def __repr__(self):
-        return str(self)
-
-    def __str__(self):
-        return self._jwe.serialize()
-
-
-class ResponseToken:
-    """Eligibility Verification API response token."""
-
-    def __init__(
-        self,
-        response: requests.models.Response,
-        jwe_encryption_alg: str,
-        jwe_cek_enc: str,
-        client_private_jwk: jwk.JWK,
-        jws_signing_alg: str,
-        server_public_jwk: jwk.JWK,
-    ):
-        logger.info("Read encrypted token from response")
-
-        try:
-            encrypted_signed_token = response.text
-            if not encrypted_signed_token:
-                raise ValueError()
-            # strip extra spaces and wrapping quote chars
-            encrypted_signed_token = encrypted_signed_token.strip("'\n\"")
-        except ValueError:
-            raise TokenError("Invalid response format")
-
-        logger.debug("Decrypt response token using agency's private key")
-        allowed_algs = [jwe_encryption_alg, jwe_cek_enc]
-        decrypted_token = jwe.JWE(algs=allowed_algs)
-        try:
-            decrypted_token.deserialize(encrypted_signed_token, key=client_private_jwk)
-        except jwe.InvalidJWEData:
-            raise TokenError("Invalid JWE token")
-        except jwe.InvalidJWEOperation:
-            raise TokenError("JWE token decryption failed")
-
-        decrypted_payload = str(decrypted_token.payload, "utf-8")
-
-        logger.debug(
-            "Verify decrypted response token's signature using verifier's public key"
-        )
-        signed_token = jws.JWS()
-        try:
-            signed_token.deserialize(
-                decrypted_payload, key=server_public_jwk, alg=jws_signing_alg
-            )
-        except jws.InvalidJWSObject:
-            raise TokenError("Invalid JWS token")
-        except jws.InvalidJWSSignature:
-            raise TokenError("JWS token signature verification failed")
-
-        logger.info("Response token decrypted and signature verified")
-
-        payload = json.loads(str(signed_token.payload, "utf-8"))
-        self.eligibility = list(payload.get("eligibility", []))
-        self.error = payload.get("error", None)
 
 
 class Client:

--- a/eligibility_api/client.py
+++ b/eligibility_api/client.py
@@ -145,10 +145,10 @@ class Client:
         issuer,
         agency,
         jws_signing_alg,
-        client_private_key_bytes,
+        client_private_key,
         jwe_encryption_alg,
         jwe_cek_enc,
-        server_public_key_bytes,
+        server_public_key,
         headers={},
     ):
         self.verify_url = verify_url
@@ -156,10 +156,10 @@ class Client:
         self.issuer = issuer
         self.agency = agency
         self.jws_signing_alg = jws_signing_alg
-        self.client_private_jwk = self._jwk(client_private_key_bytes)
+        self.client_private_jwk = self._jwk(client_private_key)
         self.jwe_encryption_alg = jwe_encryption_alg
         self.jwe_cek_enc = jwe_cek_enc
-        self.server_public_jwk = self._jwk(server_public_key_bytes)
+        self.server_public_jwk = self._jwk(server_public_key)
 
         if "authorization" in set(k.lower() for k in headers):
             raise ValueError(
@@ -168,8 +168,11 @@ class Client:
 
         self.headers = headers
 
-    def _jwk(self, pem_bytes):
-        return jwk.JWK.from_pem(pem_bytes)
+    def _jwk(self, pem_data):
+        if isinstance(pem_data, str):
+            pem_data = bytes(pem_data, "utf-8")
+
+        return jwk.JWK.from_pem(pem_data)
 
     def _tokenize_request(self, sub, name, types):
         """Create a request token."""

--- a/eligibility_api/client.py
+++ b/eligibility_api/client.py
@@ -3,7 +3,7 @@ import requests
 
 from jwcrypto import common as jwcrypto
 
-from .tokens import create_jwk, RequestToken, ResponseToken, TokenError
+from .tokens import RequestToken, ResponseToken, TokenError
 
 
 logger = logging.getLogger(__name__)
@@ -35,10 +35,10 @@ class Client:
         self.issuer = issuer
         self.agency = agency
         self.jws_signing_alg = jws_signing_alg
-        self.client_private_jwk = create_jwk(client_private_key)
+        self.client_private_key = client_private_key
         self.jwe_encryption_alg = jwe_encryption_alg
         self.jwe_cek_enc = jwe_cek_enc
-        self.server_public_jwk = create_jwk(server_public_key)
+        self.server_public_key = server_public_key
 
         if "authorization" in set(k.lower() for k in headers):
             raise ValueError(
@@ -53,10 +53,10 @@ class Client:
             types,
             self.agency,
             self.jws_signing_alg,
-            self.client_private_jwk,
+            self.client_private_key,
             self.jwe_encryption_alg,
             self.jwe_cek_enc,
-            self.server_public_jwk,
+            self.server_public_key,
             sub,
             name,
             self.issuer,
@@ -68,9 +68,9 @@ class Client:
             response,
             self.jwe_encryption_alg,
             self.jwe_cek_enc,
-            self.client_private_jwk,
+            self.client_private_key,
             self.jws_signing_alg,
-            self.server_public_jwk,
+            self.server_public_key,
         )
 
     def _auth_headers(self, token):

--- a/eligibility_api/client.py
+++ b/eligibility_api/client.py
@@ -7,6 +7,8 @@ import requests
 from jwcrypto import common as jwcrypto, jwe, jws, jwt, jwk
 from typing import Iterable
 
+from .common import create_jwk
+
 
 logger = logging.getLogger(__name__)
 
@@ -156,10 +158,10 @@ class Client:
         self.issuer = issuer
         self.agency = agency
         self.jws_signing_alg = jws_signing_alg
-        self.client_private_jwk = self._jwk(client_private_key)
+        self.client_private_jwk = create_jwk(client_private_key)
         self.jwe_encryption_alg = jwe_encryption_alg
         self.jwe_cek_enc = jwe_cek_enc
-        self.server_public_jwk = self._jwk(server_public_key)
+        self.server_public_jwk = create_jwk(server_public_key)
 
         if "authorization" in set(k.lower() for k in headers):
             raise ValueError(
@@ -167,12 +169,6 @@ class Client:
             )
 
         self.headers = headers
-
-    def _jwk(self, pem_data):
-        if isinstance(pem_data, str):
-            pem_data = bytes(pem_data, "utf-8")
-
-        return jwk.JWK.from_pem(pem_data)
 
     def _tokenize_request(self, sub, name, types):
         """Create a request token."""

--- a/eligibility_api/client.py
+++ b/eligibility_api/client.py
@@ -141,14 +141,14 @@ class Client:
 
     def __init__(
         self,
-        verify_url,
-        issuer,
-        agency,
-        jws_signing_alg,
-        client_private_jwk,
-        jwe_encryption_alg,
-        jwe_cek_enc,
-        server_public_jwk,
+        verify_url: str,
+        issuer: str,
+        agency: str,
+        jws_signing_alg: str,
+        client_private_jwk: jwk.JWK,
+        jwe_encryption_alg: str,
+        jwe_cek_enc: str,
+        server_public_jwk: jwk.JWK,
         headers={},
     ):
         self.verify_url = verify_url

--- a/eligibility_api/client.py
+++ b/eligibility_api/client.py
@@ -23,22 +23,6 @@ class TokenError(Exception):
     pass
 
 
-class JWK:
-    """JSON Web Key for use during signing or encrypting."""
-
-    @classmethod
-    def from_pem(cls, data, password=None):
-        obj = cls()
-        obj.key = jwk.JWK.from_pem(data, password)
-        return obj
-
-    def __repr__(self):
-        return str(self)
-
-    def __str__(self):
-        return str(self.key)
-
-
 class RequestToken:
     """Eligibility Verification API request token."""
 
@@ -157,14 +141,14 @@ class Client:
 
     def __init__(
         self,
-        verify_url: str,
-        issuer: str,
-        agency: str,
-        jws_signing_alg: str,
-        client_private_jwk: JWK,
-        jwe_encryption_alg: str,
-        jwe_cek_enc: str,
-        server_public_jwk: JWK,
+        verify_url,
+        issuer,
+        agency,
+        jws_signing_alg,
+        client_private_key_bytes,
+        jwe_encryption_alg,
+        jwe_cek_enc,
+        server_public_key_bytes,
         headers={},
     ):
         self.verify_url = verify_url
@@ -172,10 +156,10 @@ class Client:
         self.issuer = issuer
         self.agency = agency
         self.jws_signing_alg = jws_signing_alg
-        self.client_private_jwk = client_private_jwk.key
+        self.client_private_jwk = self._jwk(client_private_key_bytes)
         self.jwe_encryption_alg = jwe_encryption_alg
         self.jwe_cek_enc = jwe_cek_enc
-        self.server_public_jwk = server_public_jwk.key
+        self.server_public_jwk = self._jwk(server_public_key_bytes)
 
         if "authorization" in set(k.lower() for k in headers):
             raise ValueError(
@@ -183,6 +167,9 @@ class Client:
             )
 
         self.headers = headers
+
+    def _jwk(self, pem_bytes):
+        return jwk.JWK.from_pem(pem_bytes)
 
     def _tokenize_request(self, sub, name, types):
         """Create a request token."""

--- a/eligibility_api/common.py
+++ b/eligibility_api/common.py
@@ -1,8 +1,0 @@
-from jwcrypto import jwk
-
-
-def create_jwk(self, pem_data):
-    if isinstance(pem_data, str):
-        pem_data = bytes(pem_data, "utf-8")
-
-    return jwk.JWK.from_pem(pem_data)

--- a/eligibility_api/common.py
+++ b/eligibility_api/common.py
@@ -1,0 +1,8 @@
+from jwcrypto import jwk
+
+
+def create_jwk(self, pem_data):
+    if isinstance(pem_data, str):
+        pem_data = bytes(pem_data, "utf-8")
+
+    return jwk.JWK.from_pem(pem_data)

--- a/eligibility_api/server.py
+++ b/eligibility_api/server.py
@@ -2,7 +2,9 @@ import datetime
 import json
 import logging
 
-from jwcrypto import jwe, jws, jwk, jwt
+from jwcrypto import jwe, jws, jwt
+
+from .client import JWK
 
 logger = logging.getLogger(__name__)
 
@@ -11,20 +13,20 @@ def get_token_payload(
     token: str,
     jwe_encryption_alg: str,
     jwe_cek_enc: str,
-    server_private_key: jwk.JWK,
+    server_private_key: JWK,
     jws_signing_alg: str,
-    client_public_key: jwk.JWK,
+    client_public_key: JWK,
 ) -> dict:
     """Decode a token (JWE(JWS))."""
     try:
         # decrypt
         decrypted_token = jwe.JWE(algs=[jwe_encryption_alg, jwe_cek_enc])
-        decrypted_token.deserialize(token, key=server_private_key)
+        decrypted_token.deserialize(token, key=server_private_key.key)
         decrypted_payload = str(decrypted_token.payload, "utf-8")
         # verify signature
         signed_token = jws.JWS()
         signed_token.deserialize(
-            decrypted_payload, key=client_public_key, alg=jws_signing_alg
+            decrypted_payload, key=client_public_key.key, alg=jws_signing_alg
         )
         # return final payload
         payload = str(signed_token.payload, "utf-8")
@@ -50,16 +52,16 @@ def create_response_payload(token_payload: dict, issuer: str) -> dict:
 def make_token(
     payload: dict,
     jws_signing_alg: str,
-    server_private_key: jwk.JWK,
+    server_private_key: JWK,
     jwe_encryption_alg: str,
     jwe_cek_enc: str,
-    client_public_key: jwk.JWK,
+    client_public_key: JWK,
 ) -> str:
     """Wrap payload in a signed and encrypted JWT for response."""
     # sign the payload with server's private key
     header = {"typ": "JWS", "alg": jws_signing_alg}
     signed_token = jwt.JWT(header=header, claims=payload)
-    signed_token.make_signed_token(server_private_key)
+    signed_token.make_signed_token(server_private_key.key)
     signed_payload = signed_token.serialize()
     # encrypt the signed payload with client's public key
     header = {
@@ -68,5 +70,5 @@ def make_token(
         "enc": jwe_cek_enc,
     }
     encrypted_token = jwt.JWT(header=header, claims=signed_payload)
-    encrypted_token.make_encrypted_token(client_public_key)
+    encrypted_token.make_encrypted_token(client_public_key.key)
     return encrypted_token.serialize()

--- a/eligibility_api/server.py
+++ b/eligibility_api/server.py
@@ -4,7 +4,7 @@ import logging
 
 from jwcrypto import jwe, jws, jwt
 
-from .common import create_jwk
+from .tokens import create_jwk
 
 logger = logging.getLogger(__name__)
 

--- a/eligibility_api/server.py
+++ b/eligibility_api/server.py
@@ -7,28 +7,31 @@ from jwcrypto import jwe, jws, jwk, jwt
 logger = logging.getLogger(__name__)
 
 
-def _jwk(pem_bytes):
-    return jwk.JWK.from_pem(pem_bytes)
+def _jwk(pem_data):
+    if isinstance(pem_data, str):
+        pem_data = bytes(pem_data, "utf-8")
+
+    return jwk.JWK.from_pem(pem_data)
 
 
 def get_token_payload(
     token: str,
     jwe_encryption_alg: str,
     jwe_cek_enc: str,
-    server_private_key_bytes,
+    server_private_key,
     jws_signing_alg: str,
-    client_public_key_bytes,
+    client_public_key,
 ) -> dict:
     """Decode a token (JWE(JWS))."""
     try:
         # decrypt
         decrypted_token = jwe.JWE(algs=[jwe_encryption_alg, jwe_cek_enc])
-        decrypted_token.deserialize(token, key=_jwk(server_private_key_bytes))
+        decrypted_token.deserialize(token, key=_jwk(server_private_key))
         decrypted_payload = str(decrypted_token.payload, "utf-8")
         # verify signature
         signed_token = jws.JWS()
         signed_token.deserialize(
-            decrypted_payload, key=_jwk(client_public_key_bytes), alg=jws_signing_alg
+            decrypted_payload, key=_jwk(client_public_key), alg=jws_signing_alg
         )
         # return final payload
         payload = str(signed_token.payload, "utf-8")
@@ -54,16 +57,16 @@ def create_response_payload(token_payload: dict, issuer: str) -> dict:
 def make_token(
     payload: dict,
     jws_signing_alg: str,
-    server_private_key_bytes,
+    server_private_key,
     jwe_encryption_alg: str,
     jwe_cek_enc: str,
-    client_public_key_bytes,
+    client_public_key,
 ) -> str:
     """Wrap payload in a signed and encrypted JWT for response."""
     # sign the payload with server's private key
     header = {"typ": "JWS", "alg": jws_signing_alg}
     signed_token = jwt.JWT(header=header, claims=payload)
-    signed_token.make_signed_token(_jwk(server_private_key_bytes))
+    signed_token.make_signed_token(_jwk(server_private_key))
     signed_payload = signed_token.serialize()
     # encrypt the signed payload with client's public key
     header = {
@@ -72,5 +75,5 @@ def make_token(
         "enc": jwe_cek_enc,
     }
     encrypted_token = jwt.JWT(header=header, claims=signed_payload)
-    encrypted_token.make_encrypted_token(_jwk(client_public_key_bytes))
+    encrypted_token.make_encrypted_token(_jwk(client_public_key))
     return encrypted_token.serialize()

--- a/eligibility_api/server.py
+++ b/eligibility_api/server.py
@@ -4,7 +4,7 @@ import logging
 
 from jwcrypto import jwe, jws, jwt
 
-from .tokens import create_jwk
+from .tokens import _create_jwk
 
 logger = logging.getLogger(__name__)
 
@@ -21,12 +21,12 @@ def get_token_payload(
     try:
         # decrypt
         decrypted_token = jwe.JWE(algs=[jwe_encryption_alg, jwe_cek_enc])
-        decrypted_token.deserialize(token, key=create_jwk(server_private_key))
+        decrypted_token.deserialize(token, key=_create_jwk(server_private_key))
         decrypted_payload = str(decrypted_token.payload, "utf-8")
         # verify signature
         signed_token = jws.JWS()
         signed_token.deserialize(
-            decrypted_payload, key=create_jwk(client_public_key), alg=jws_signing_alg
+            decrypted_payload, key=_create_jwk(client_public_key), alg=jws_signing_alg
         )
         # return final payload
         payload = str(signed_token.payload, "utf-8")
@@ -61,7 +61,7 @@ def make_token(
     # sign the payload with server's private key
     header = {"typ": "JWS", "alg": jws_signing_alg}
     signed_token = jwt.JWT(header=header, claims=payload)
-    signed_token.make_signed_token(create_jwk(server_private_key))
+    signed_token.make_signed_token(_create_jwk(server_private_key))
     signed_payload = signed_token.serialize()
     # encrypt the signed payload with client's public key
     header = {
@@ -70,5 +70,5 @@ def make_token(
         "enc": jwe_cek_enc,
     }
     encrypted_token = jwt.JWT(header=header, claims=signed_payload)
-    encrypted_token.make_encrypted_token(create_jwk(client_public_key))
+    encrypted_token.make_encrypted_token(_create_jwk(client_public_key))
     return encrypted_token.serialize()

--- a/eligibility_api/server.py
+++ b/eligibility_api/server.py
@@ -2,31 +2,33 @@ import datetime
 import json
 import logging
 
-from jwcrypto import jwe, jws, jwt
-
-from .client import JWK
+from jwcrypto import jwe, jws, jwk, jwt
 
 logger = logging.getLogger(__name__)
+
+
+def _jwk(pem_bytes):
+    return jwk.JWK.from_pem(pem_bytes)
 
 
 def get_token_payload(
     token: str,
     jwe_encryption_alg: str,
     jwe_cek_enc: str,
-    server_private_key: JWK,
+    server_private_key_bytes,
     jws_signing_alg: str,
-    client_public_key: JWK,
+    client_public_key_bytes,
 ) -> dict:
     """Decode a token (JWE(JWS))."""
     try:
         # decrypt
         decrypted_token = jwe.JWE(algs=[jwe_encryption_alg, jwe_cek_enc])
-        decrypted_token.deserialize(token, key=server_private_key.key)
+        decrypted_token.deserialize(token, key=_jwk(server_private_key_bytes))
         decrypted_payload = str(decrypted_token.payload, "utf-8")
         # verify signature
         signed_token = jws.JWS()
         signed_token.deserialize(
-            decrypted_payload, key=client_public_key.key, alg=jws_signing_alg
+            decrypted_payload, key=_jwk(client_public_key_bytes), alg=jws_signing_alg
         )
         # return final payload
         payload = str(signed_token.payload, "utf-8")
@@ -52,16 +54,16 @@ def create_response_payload(token_payload: dict, issuer: str) -> dict:
 def make_token(
     payload: dict,
     jws_signing_alg: str,
-    server_private_key: JWK,
+    server_private_key_bytes,
     jwe_encryption_alg: str,
     jwe_cek_enc: str,
-    client_public_key: JWK,
+    client_public_key_bytes,
 ) -> str:
     """Wrap payload in a signed and encrypted JWT for response."""
     # sign the payload with server's private key
     header = {"typ": "JWS", "alg": jws_signing_alg}
     signed_token = jwt.JWT(header=header, claims=payload)
-    signed_token.make_signed_token(server_private_key.key)
+    signed_token.make_signed_token(_jwk(server_private_key_bytes))
     signed_payload = signed_token.serialize()
     # encrypt the signed payload with client's public key
     header = {
@@ -70,5 +72,5 @@ def make_token(
         "enc": jwe_cek_enc,
     }
     encrypted_token = jwt.JWT(header=header, claims=signed_payload)
-    encrypted_token.make_encrypted_token(client_public_key.key)
+    encrypted_token.make_encrypted_token(_jwk(client_public_key_bytes))
     return encrypted_token.serialize()

--- a/eligibility_api/tokens.py
+++ b/eligibility_api/tokens.py
@@ -1,0 +1,136 @@
+import datetime
+import json
+import logging
+import uuid
+
+from jwcrypto import jwe, jws, jwt, jwk
+from typing import Iterable
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+def create_jwk(pem_data):
+    if isinstance(pem_data, str):
+        pem_data = bytes(pem_data, "utf-8")
+
+    return jwk.JWK.from_pem(pem_data)
+
+
+class TokenError(Exception):
+    """Error with API request/response token."""
+
+    pass
+
+
+class RequestToken:
+    """Eligibility Verification API request token."""
+
+    def __init__(
+        self,
+        types: Iterable[str],
+        agency: str,
+        jws_signing_alg: str,
+        client_private_jwk: jwk.JWK,
+        jwe_encryption_alg: str,
+        jwe_cek_enc: str,
+        server_public_jwk: jwk.JWK,
+        sub: str,
+        name: str,
+        issuer: str,
+    ):
+        logger.info("Initialize new request token")
+
+        # craft the main token payload
+        payload = dict(
+            jti=str(uuid.uuid4()),
+            iss=issuer,
+            iat=int(
+                datetime.datetime.utcnow()
+                .replace(tzinfo=datetime.timezone.utc)
+                .timestamp()
+            ),
+            agency=agency,
+            eligibility=types,
+            sub=sub,
+            name=name,
+        )
+
+        logger.debug("Sign token payload with agency's private key")
+        header = {"typ": "JWS", "alg": jws_signing_alg}
+        signed_token = jwt.JWT(header=header, claims=payload)
+        signed_token.make_signed_token(client_private_jwk)
+        signed_payload = signed_token.serialize()
+
+        logger.debug("Encrypt signed token payload with verifier's public key")
+        header = {
+            "typ": "JWE",
+            "alg": jwe_encryption_alg,
+            "enc": jwe_cek_enc,
+        }
+        encrypted_token = jwt.JWT(header=header, claims=signed_payload)
+        encrypted_token.make_encrypted_token(server_public_jwk)
+
+        logger.info("Signed and encrypted request token initialized")
+        self._jwe = encrypted_token
+
+    def __repr__(self):
+        return str(self)
+
+    def __str__(self):
+        return self._jwe.serialize()
+
+
+class ResponseToken:
+    """Eligibility Verification API response token."""
+
+    def __init__(
+        self,
+        response: requests.models.Response,
+        jwe_encryption_alg: str,
+        jwe_cek_enc: str,
+        client_private_jwk: jwk.JWK,
+        jws_signing_alg: str,
+        server_public_jwk: jwk.JWK,
+    ):
+        logger.info("Read encrypted token from response")
+
+        try:
+            encrypted_signed_token = response.text
+            if not encrypted_signed_token:
+                raise ValueError()
+            # strip extra spaces and wrapping quote chars
+            encrypted_signed_token = encrypted_signed_token.strip("'\n\"")
+        except ValueError:
+            raise TokenError("Invalid response format")
+
+        logger.debug("Decrypt response token using agency's private key")
+        allowed_algs = [jwe_encryption_alg, jwe_cek_enc]
+        decrypted_token = jwe.JWE(algs=allowed_algs)
+        try:
+            decrypted_token.deserialize(encrypted_signed_token, key=client_private_jwk)
+        except jwe.InvalidJWEData:
+            raise TokenError("Invalid JWE token")
+        except jwe.InvalidJWEOperation:
+            raise TokenError("JWE token decryption failed")
+
+        decrypted_payload = str(decrypted_token.payload, "utf-8")
+
+        logger.debug(
+            "Verify decrypted response token's signature using verifier's public key"
+        )
+        signed_token = jws.JWS()
+        try:
+            signed_token.deserialize(
+                decrypted_payload, key=server_public_jwk, alg=jws_signing_alg
+            )
+        except jws.InvalidJWSObject:
+            raise TokenError("Invalid JWS token")
+        except jws.InvalidJWSSignature:
+            raise TokenError("JWS token signature verification failed")
+
+        logger.info("Response token decrypted and signature verified")
+
+        payload = json.loads(str(signed_token.payload, "utf-8"))
+        self.eligibility = list(payload.get("eligibility", []))
+        self.error = payload.get("error", None)


### PR DESCRIPTION
This PR changes the `client` and `server` modules so that anywhere that a JWK is needed, the API expects the consumer to pass in the data directly (either as a string or a bytes-like object). The API will internally figure out what to do with the data.