### PR TITLE
Chore: fix 'prefix' string in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     schedule:
       interval: "daily"
     commit-message:
-      prefix: "chore(deps): "
+      prefix: "chore"
       include: "scope"
     labels:
       - "dependencies"
@@ -21,7 +21,7 @@ updates:
     schedule:
       interval: "daily"
     commit-message:
-      prefix: "chore(deps): "
+      prefix: "chore"
       include: "scope"
     labels:
       - "dependencies"


### PR DESCRIPTION
The `prefix` string in this project's Dependabot config redundantly includes the scope. https://github.com/cal-itp/eligibility-api/pull/36 is an example PR with the duplication. ("`chore(deps): (deps):`"). This PR fixes the issue.