### PR TITLE
Feat: publish package to PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version-file: .github/workflows/.python-version
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,37 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v3
+        with:
+          python-version-file: .github/workflows/.python-version
+
+      - name: Install build dependencies
+        run: pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Publish to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1.5
+        if: "github.event.release.prerelease"
+        with:
+          username: __token__
+          password: ${{ secrets.PYPI_TEST_API_TOKEN }}
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1.5
+        if: "!github.event.release.prerelease"
+        with:
+          username: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,12 +26,17 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1.5
         if: "github.event.release.prerelease"
         with:
-          username: __token__
+          user: __token__
           password: ${{ secrets.PYPI_TEST_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+          print_hash: true
+          skip_existing: true
+          verbose: true
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1.5
         if: "!github.event.release.prerelease"
         with:
-          username: __token__
+          user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
+          print_hash: true

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ __pycache__/
 .coverage
 .DS_Store
 build/
-eligibility.egg-info/
+eligibility_api.egg-info/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=42",
+    "setuptools>=65",
     "wheel"
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,8 @@
 name = eligibility_api
 version = 2023.01.1
 description = Data exchange to verify eligibility for transit benefits
+long_description = file: README.md
+long_description_content_type = text/markdown
 url = https://github.com/cal-itp/eligibility-api
 project_urls =
     Bug Tracker = https://github.com/cal-itp/eligibility-api/issues

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,7 @@ url = https://github.com/cal-itp/eligibility-api
 project_urls =
     Bug Tracker = https://github.com/cal-itp/eligibility-api/issues
 license = 'Apache 2.0'
+license_file = LICENSE
 classifiers =
     Programming Language :: Python :: 3
     License :: OSI Approved :: Apache Software License

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = eligibility_api
-version = 2022.01.1
+version = 2023.01.1
 description = Data exchange to verify eligibility for transit benefits
 url = https://github.com/cal-itp/eligibility-api
 project_urls =


### PR DESCRIPTION
Closes #22

## Overview

This PR updates our package configuration files (`setup.cfg` and `pyproject.toml`) and introduces a workflow to publish to PyPI when we make a new release on GitHub.

## Other work done
API tokens (scoped to `eligibility-api`) have been created on PyPI/TestPyPI and added to this GitHub repository as secrets so that the workflow can handle our future releases.

For this initial release, I installed `build` and `twine` in the devcontainer and created short-lived API tokens on PyPI/TestPyPI to upload the distribution files.

See the published package at:
 - PyPI: https://pypi.org/project/eligibility-api/ 
 - TestPyPI: https://test.pypi.org/project/eligibility-api/
    - (Note: I was testing some changes to `setup.cfg` and had to upload with a locally-bumped version since you can't reupload with the same name)
