### PR TITLE
Fix: docs workflow trying to download expired coverage report

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Download coverage report
         uses: dawidd6/action-download-artifact@v6
         with:
-          workflow: tests-pytest.yml
+          workflow: pytest.yml
           branch: main
           event: push
           name: coverage-report


### PR DESCRIPTION
From the [latest failed run of `Publish docs`](https://github.com/cal-itp/eligibility-api/actions/runs/9911640490/job/27384753093#step:4:31):
> Error: no downloadable artifacts found (expired)

The problem was that the `mkdocs.yml` workflow has a step to download an artifact from `test-pytest.yml`, but that workflow is now named `pytest.yml`.

The rename was done in [Sep 2023](https://github.com/cal-itp/eligibility-api/commit/751537ee68953e23517a0828fe9a234c45f46531#diff-d79d541279309f16c3c9caefd538b861f8c9a8e76e231824ad380886b350aa9c); the `mkdocs.yml` workflow started failing in Dec 2023, which makes sense -- the artifact from the old workflow is probably cached for some time.

![image](https://github.com/user-attachments/assets/4eb80e24-4671-46f7-933f-af85ece9f9e5)
