### PR TITLE
Fix: add back step for uploading coverage report as artifact

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -33,6 +33,12 @@ jobs:
       - name: Run tests
         run: ./bin/coverage.sh
 
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-report
+          path: coverage
+
       - name: Coverage comment
         uses: py-cov-action/python-coverage-comment-action@v3
         with:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: coverage-report
-          path: coverage
+          path: tests/coverage
 
       - name: Coverage comment
         uses: py-cov-action/python-coverage-comment-action@v3


### PR DESCRIPTION
Follow-up to #97 

The `Publish docs` workflow [failed again](https://github.com/cal-itp/eligibility-api/actions/runs/9911958734/job/27385739230#step:4:31) for a different reason: the `coverage-report` could not be found.

This PR adds back a step to `pytest.yml` to upload the artifact.

The step was [removed in #69](https://github.com/cal-itp/eligibility-api/commit/751537ee68953e23517a0828fe9a234c45f46531#diff-d79d541279309f16c3c9caefd538b861f8c9a8e76e231824ad380886b350aa9cL29-L33), but I don't have any reason to believe it was intentional. 🤔 