### PR TITLE
Fix(docs): remove broken/unused extension

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,3 @@
-fontawesome_markdown
 mkdocs
 mkdocs-awesome-pages-plugin
 mkdocs-macros-plugin

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,4 +57,3 @@ markdown_extensions:
       # insert a blank space before the character
       permalink: " ¶"
   - smarty
-  - fontawesome_markdown


### PR DESCRIPTION
Prompted by [latest build failure](https://github.com/cal-itp/eligibility-api/actions/runs/9914006224/job/27392217016#step:5:77) for the docs site

I found this old branch with the code changes, so I'm opening a pull request for it. It is similar to https://github.com/cal-itp/eligibility-server/pull/320.

The details on why the extension is broken is documented in https://github.com/squidfunk/mkdocs-material/issues/4129

