### PR TITLE
Chore: bump `gh-action-pypi-publish` version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
         run: python -m build
 
       - name: Publish to Test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1.5
+        uses: pypa/gh-action-pypi-publish@release/v1
         if: "github.event.release.prerelease"
         with:
           user: __token__
@@ -34,7 +34,7 @@ jobs:
           verbose: true
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1.5
+        uses: pypa/gh-action-pypi-publish@release/v1
         if: "!github.event.release.prerelease"
         with:
           user: __token__


### PR DESCRIPTION
The `publish` workflow was using version 1.5 of `gh-action-pypi-publish` and was [failing](https://github.com/cal-itp/eligibility-api/actions/runs/14367190518). Updating it to just use the latest version (`v1`, what the [Cal-ITP Littlepay repo uses](https://github.com/cal-itp/littlepay/blob/main/.github/workflows/release.yml#L45)) fixed the problem.
