### PR TITLE
Docs: Use same docs theme as Benefits

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,20 +8,7 @@ theme:
   features:
     - navigation.tabs
   palette:
-    - media: "(prefers-color-scheme: light)"
-      scheme: default
-      primary: blue
-      accent: amber
-      toggle:
-        icon: material/toggle-switch-off-outline
-        name: Switch to dark mode
-    - media: "(prefers-color-scheme: dark)"
-      scheme: slate
-      primary: blue
-      accent: amber
-      toggle:
-        icon: material/toggle-switch
-        name: Switch to light mode
+    scheme: default
 
 extra:
   analytics:
@@ -37,6 +24,7 @@ extra_javascript:
 
 extra_css:
   - https://use.fontawesome.com/releases/v5.13.0/css/all.css
+  - https://docs.calitp.org/benefits/styles/theme.css
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
closes #110 

- Uses same approach as https://github.com/cal-itp/eligibility-server/pull/558/files

<img width="1257" height="910" alt="image" src="https://github.com/user-attachments/assets/f8fc1f48-ba12-4f1c-ac68-66bfef78333d" />
